### PR TITLE
dockerized cerebro container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM java:openjdk-8u92-jre-alpine
+MAINTAINER Global Solutions co., ltd.
+LABEL semver="0.1.0"
+
+ENV CEREBRO_VER=0.2.0
+
+WORKDIR cerebro
+RUN apk add --update --no-cache openssl tar bash && \
+    wget -O - https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VER}/cerebro-${CEREBRO_VER}.tgz | tar xzv --strip-components 1 && \
+    apk del openssl tar && \
+    rm -rf /var/cache/apk/*
+
+EXPOSE 9000
+ENTRYPOINT ["/cerebro/bin/cerebro"]


### PR DESCRIPTION
## What

Dockerfile for cerebro container. it is an elasticsearch web admin tool.
## Why
- make it easy to launch a server
- plugins are not supported in Elasticsearch 5.0
